### PR TITLE
add darwin arm64 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ if (platform !== 'darwin' && platform !=='linux' && platform !== 'win32') {
 }
 
 var arch = os.arch();
-if (platform === 'darwin' && arch !== 'x64') {
+if (platform === 'darwin' && arch !== 'x64' && arch !== 'arm64') {
   console.error('Unsupported architecture.');
   process.exit(1);
 }


### PR DESCRIPTION
ffprobe-static was not working on my mac(apple silicon m1).Then I found the problem was that the darwin arm64 binary not exist.
In this pull request the darwin arm64 binary is added to support apple silicon m1.